### PR TITLE
debian/rules: Make the build verbose

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ override_dh_auto_configure:
 	(cd build && cmake .. ${CXXF} -DDEPENDENCY_CONFIG=../cmake-utils/DependenciesFromLocalSystem.cmake -DBUILD_TESTING=ON -DCRYFS_UPDATE_CHECKS=OFF)
 
 override_dh_auto_build:
-	(cd build && make)
+	(cd build && make VERBOSE=1)
 	./build/test/blobstore/blobstore-test
 	./build/test/blockstore/blockstore-test --gtest_filter=-CacheTest_RaceCondition.*
 	# Config Compatibility tests fail on s390x, mipsel, and hppa archs


### PR DESCRIPTION
This shows the compile commands during the build.